### PR TITLE
add font size from CSS to IconStore prop for atoms

### DIFF
--- a/src/components/atoms/Accordion/Accordion.tsx
+++ b/src/components/atoms/Accordion/Accordion.tsx
@@ -35,6 +35,7 @@ const Accordion = (props: Props) => {
               iconClass={`acc1Icon ${iconClass}`}
               width={20}
               height={20}
+              fontSize={20}
             />
             : null
         }

--- a/src/components/atoms/Accordion/accordion.css
+++ b/src/components/atoms/Accordion/accordion.css
@@ -7,5 +7,4 @@
 
 .acc1Icon {
   width: 20px;
-  font-size: 20px !important;
 }

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -59,13 +59,14 @@ class Button extends React.PureComponent<Props> {
   }
 
   getIconUI = () => {
-    const { iconName, iconPosition } = this.props;
+    const { iconName, iconPosition, fontSize } = this.props;
 
     return (
       <IconStore
         iconName={iconName}
         iconStyle={this.getComputedStyleForIcon()}
         iconClass={`btn51Icon${iconPosition} absolute-center`}
+        fontSize={fontSize ? fontSize : 24}
       />
     );
   }

--- a/src/components/atoms/Chip/Chip.tsx
+++ b/src/components/atoms/Chip/Chip.tsx
@@ -41,6 +41,7 @@ const Chip = (props: Props) => {
               iconName={iconName}
               width={14}
               height={14}
+              fontSize={14}
               iconClass={`chip12Icon ${iconClass}`}
             />
           </div>

--- a/src/components/atoms/Chip/chip.css
+++ b/src/components/atoms/Chip/chip.css
@@ -35,7 +35,6 @@
 }
 
 .chip12Icon {
-  font-size: 14px !important;
   margin-left: 4px;
 }
 

--- a/src/components/atoms/DateSelector/DateSelector.tsx
+++ b/src/components/atoms/DateSelector/DateSelector.tsx
@@ -82,6 +82,7 @@ class DateSelector extends PureComponent<Props, State> {
             <IconStore
               iconName={MI_ICON_LIST.clear}
               iconClass="date101CrossButton"
+              fontSize={19}
               onIconClick={onClose}
             />
             : null

--- a/src/components/atoms/DateSelector/dateSelector.css
+++ b/src/components/atoms/DateSelector/dateSelector.css
@@ -101,7 +101,6 @@
 .date101CrossButton {
   position: absolute;
   opacity: 0.5;
-  font-size: 19px !important;
   top: 10px;
   right: 10px;
   color: var(--text);

--- a/src/components/atoms/GoBack/GoBack.tsx
+++ b/src/components/atoms/GoBack/GoBack.tsx
@@ -28,6 +28,7 @@ const GoBack = (props: Props) => {
               iconName={MI_ICON_LIST.keyboard_arrow_left}
               width={iconWidth}
               height={iconHeight}
+              fontSize={20}
               iconClass={`gb6Icon ${iconClass}`}
             />
           </div>

--- a/src/components/atoms/GoBack/goBack.css
+++ b/src/components/atoms/GoBack/goBack.css
@@ -7,7 +7,6 @@
 }
 
 .gb6Icon {
-  font-size: 20px !important;
   margin-right: 4px;
 }
 

--- a/src/components/atoms/InformationBoard/InformationBox.tsx
+++ b/src/components/atoms/InformationBoard/InformationBox.tsx
@@ -58,7 +58,8 @@ const InformationBox = (props: Props) => {
         <IconStore
           width={20}
           height={20}
-          iconClass="fs20 clrText infbd45InfoIcon"
+          fontSize={20}
+          iconClass="clrText infbd45InfoIcon"
           iconName={icon}
         />
       }

--- a/src/components/atoms/RadioButton/RadioButton.tsx
+++ b/src/components/atoms/RadioButton/RadioButton.tsx
@@ -37,6 +37,7 @@ const RadioButton = (props: Props) => {
       <IconStore
         iconName={selected ? MI_ICON_LIST.radio_button_checked : MI_ICON_LIST.radio_button_unchecked}
         iconClass={`radioCo11Icon ${iconClassName}`}
+        fontSize={20}
       />
       <div className={labelParentClassName}>
         {label}

--- a/src/components/atoms/RadioButton/radioButton.css
+++ b/src/components/atoms/RadioButton/radioButton.css
@@ -1,7 +1,6 @@
 .radioCo11Icon {
   float: left;
   color: var(--primaryClr);
-  font-size: 20px !important;
   max-width: 20px;
   max-height: 20px;
 }

--- a/src/components/atoms/ScrollTop/ScrollTop.tsx
+++ b/src/components/atoms/ScrollTop/ScrollTop.tsx
@@ -52,6 +52,7 @@ const ScrollTop = (props: Props) => {
         iconName={MI_ICON_LIST.arrow_drop_down_circle}
         width={52}
         height={52}
+        fontSize={52}
         iconClass="cur-po scroll11Img"
       />
     </div>

--- a/src/components/atoms/ScrollTop/scrollTop.css
+++ b/src/components/atoms/ScrollTop/scrollTop.css
@@ -1,7 +1,6 @@
 .scroll11Img {
   transform: rotate(180deg);
   color: var(--primaryClr);
-  font-size: 52px !important;
   cursor: pointer;
 }
 

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -71,6 +71,7 @@ class Select extends React.PureComponent<Props> {
                   iconName={MI_ICON_LIST.keyboard_arrow_down}
                   width={22}
                   height={22}
+                  fontSize={22}
                 />
 
                 <input

--- a/src/components/atoms/Table/Components/TableHeaderCell.tsx
+++ b/src/components/atoms/Table/Components/TableHeaderCell.tsx
@@ -59,6 +59,7 @@ const TableHeaderCell = (props: Props) => {
         <IconStore
           iconName={sortConfig?.ascending ? MI_ICON_LIST.arrow_drop_up : MI_ICON_LIST.arrow_drop_down}
           iconClass={iconClasses}
+          fontSize={24}
         />
       </th>
     );


### PR DESCRIPTION
- Adding font-size with class name (iconClass, className, typograpghy - fs16…)
  - removed font-size from class name and used the same size for Prop.
  - class removed if all it was doing was adding font-size)
- No class name found which was applying font-size
  - used minimum of width and height for Prop.
  - if width and height were not passed used 24 for fontSize Prop (Default value).
 
PR for IconStore - https://github.com/Groww/ui-toolkit/pull/64